### PR TITLE
THIK-35 Restaurant module update

### DIFF
--- a/restaurant-app/data/api/src/main/java/com/dsm/api/ThikiraApi.kt
+++ b/restaurant-app/data/api/src/main/java/com/dsm/api/ThikiraApi.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 interface ThikiraApi {
 
-    @GET("")
+    @GET("/api/restaurant")
     suspend fun getRestaurantInfo(): RestaurantResponse
 
     @POST("create")

--- a/restaurant-app/data/db/src/main/java/com/dsm/db/dao/RestaurantDao.kt
+++ b/restaurant-app/data/db/src/main/java/com/dsm/db/dao/RestaurantDao.kt
@@ -18,7 +18,7 @@ interface RestaurantDao {
     suspend fun updateAddress(address: String, roadAddress: String)
 
     @Query("select * from restaurant")
-    fun observeRestaurant(): LiveData<RestaurantEntity>
+    fun observeRestaurant(): LiveData<RestaurantEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(restaurant: RestaurantEntity)

--- a/restaurant-app/data/db/src/main/java/com/dsm/db/dataSource/LocalRestaurantDataSource.kt
+++ b/restaurant-app/data/db/src/main/java/com/dsm/db/dataSource/LocalRestaurantDataSource.kt
@@ -14,7 +14,7 @@ interface LocalRestaurantDataSource {
 
     suspend fun changeAddress(address: String, roadAddress: String)
 
-    fun observeRestaurantInfo(): LiveData<RestaurantEntity>
+    fun observeRestaurantInfo(): LiveData<RestaurantEntity?>
 
     suspend fun insertRestaurantInfo(restaurant: RestaurantEntity)
 
@@ -34,7 +34,7 @@ class LocalRestaurantDataSourceImpl(
         restaurantDao.updateAddress(address, roadAddress)
     }
 
-    override fun observeRestaurantInfo(): LiveData<RestaurantEntity> =
+    override fun observeRestaurantInfo(): LiveData<RestaurantEntity?> =
         restaurantDao.observeRestaurant()
 
     override suspend fun insertRestaurantInfo(restaurant: RestaurantEntity) = withContext(ioDispatcher) {

--- a/restaurant-app/data/repository/src/main/java/com/dsm/repository/RestaurantRepositoryImpl.kt
+++ b/restaurant-app/data/repository/src/main/java/com/dsm/repository/RestaurantRepositoryImpl.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import com.dsm.api.dataSource.RemoteRestaurantDataSource
 import com.dsm.db.dataSource.LocalRestaurantDataSource
-import com.dsm.db.entity.RestaurantEntity
 import com.dsm.mapper.toEntity
 import com.dsm.mapper.toRestaurant
 import com.dsm.model.Address
@@ -31,7 +30,9 @@ class RestaurantRepositoryImpl(
     }
 
     override fun observeRestaurantInfo(): LiveData<Restaurant> =
-        localRestaurantDataSource.observeRestaurantInfo().map(RestaurantEntity::toRestaurant)
+        localRestaurantDataSource.observeRestaurantInfo().map {
+            it?.toRestaurant() ?: Restaurant()
+        }
 
     override suspend fun refreshRestaurantInfo() = withContext(ioDispatcher) {
         remoteRestaurantDataSource.getRestaurantInfo().let {
@@ -39,5 +40,4 @@ class RestaurantRepositoryImpl(
             localRestaurantDataSource.insertRestaurantInfo(it.toEntity())
         }
     }
-
 }

--- a/restaurant-app/model/src/main/java/com/dsm/model/Restaurant.kt
+++ b/restaurant-app/model/src/main/java/com/dsm/model/Restaurant.kt
@@ -2,33 +2,33 @@ package com.dsm.model
 
 data class Restaurant(
 
-    val name: String,
+    val name: String = "",
 
-    val image: String,
+    val image: String = "",
 
-    val phone: String,
+    val phone: String = "",
 
-    val deliverableArea: String,
+    val deliverableArea: String = "",
 
-    val category: String,
+    val category: String = "",
 
-    val minPrice: Int,
+    val minPrice: Int = 0,
 
-    val dayOff: String,
+    val dayOff: String = "",
 
-    val isOnlinePayment: Boolean,
+    val isOnlinePayment: Boolean = false,
 
-    val isOfflinePayment: Boolean,
+    val isOfflinePayment: Boolean = false,
 
-    val openTime: String,
+    val openTime: String = "",
 
-    val closeTime: String,
+    val closeTime: String = "",
 
-    val description: String,
+    val description: String = "",
 
-    val email: String,
+    val email: String = "",
 
-    val address: String,
+    val address: String = "",
 
-    val roadAddress: String
+    val roadAddress: String = ""
 )


### PR DESCRIPTION
LiveData에서 restaurat 정보를 불러올 때 null을 가져와 에러가 나는 것을 해결함
observeRestaurant()에서 리턴값을 nullable로 변경하여, 만약 null이라면 빈 객체를 리턴하도록 함